### PR TITLE
[KYC Fill-in] Correction of example for gender attribute

### DIFF
--- a/code/API_definitions/kyc-fill-in.yaml
+++ b/code/API_definitions/kyc-fill-in.yaml
@@ -186,7 +186,7 @@ paths:
                     houseNumberExtension: 36
                     birthdate: '1978-08-22'
                     email: abc@example.com
-                    gender: male
+                    gender: MALE
 
         "400":
           $ref: '#/components/responses/Generic400'
@@ -320,7 +320,7 @@ components:
           
         gender:
           type: string
-          description: Gender of the customer stored on the Operator's system (male/female/other).
+          description: Gender of the customer stored on the Operator's system (Male/Female/Other).
           enum:
             - MALE
             - FEMALE


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

* Correct gender example in the kyc-fill-in yaml  (-L189: gender: male -> gender: MALE)
* Additionally, modify description of the gender attribute to get aligned with kyc-match yaml (-L323: (male/female/other) -> (Male/Female/Other))

#### Which issue(s) this PR fixes:

Fixes KYC-Match/Fill-in/AgeVerification issue #196  ( https://github.com/camaraproject/KnowYourCustomer/issues/196 )

#### Special notes for reviewers:


-L323: (male/female/other) -> (Male/Female/Other) [getting aligned with kyc-match yaml]


#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
