### PR TITLE
[kyc-fill-in] Remove AUTHENTICATION_REQUIRED error code

### DIFF
--- a/code/API_definitions/kyc-fill-in.yaml
+++ b/code/API_definitions/kyc-fill-in.yaml
@@ -388,20 +388,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
 
     Generic403:
       description: Forbidden


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Commonalities pre-release [r3.1](https://github.com/camaraproject/Commonalities/releases/tag/r3.1) removes the `AUTHENTICATION_REQUIRED` error code, leaving `UNAUTHENTICATED` as the only valid error code when the HTTP status code is 401. This PR removes all instances of `AUTHENTICATION_REQUIRED`.

#### Which issue(s) this PR fixes:

Fixes #7 

#### Special notes for reviewers:

No need to change kyc-fill-in .feature file.

#### Changelog input

```
 release-note

```

#### Additional documentation 

None


