### PR TITLE
[kyc-fill-in] Add text on undocumented errors to OAS definition

### DIFF
--- a/code/API_definitions/kyc-fill-in.yaml
+++ b/code/API_definitions/kyc-fill-in.yaml
@@ -66,6 +66,13 @@ info:
 
     - If the subject can be identified from the access token and the optional `phoneNumber` field is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same phone number is identified by these two methods, as the server is unable to make this comparison.
 
+    ### Additional CAMARA error responses
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+
+    Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
+
+    As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Adds mandatory text on undocumented errors to the OAS info.description section as defined [here](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Design-Guide.md#33-error-responses---mandatory-template-for-infodescription-in-camara-api-specs).

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #14 

#### Special notes for reviewers:

None

#### Changelog input

```
 release-note
 - Add text on undocumented errors to OAS definition 
```

#### Additional documentation 

None

